### PR TITLE
add explicit require for rspec

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@
 $TESTING=true
 $:.push File.join(File.dirname(__FILE__), '..', 'lib')
 
+require 'rspec'
 require 'mixlib/log'
 require 'mixlib/log/formatter'
 


### PR DESCRIPTION
Without explicit require 'rspec', tests fail with 

./spec/mixlib/log_spec.rb:40: undefined method `describe' for main:Object (NoMethodError)
    from debian/ruby-tests.rb:1:in`require'
    from debian/ruby-tests.rb:1
    from debian/ruby-tests.rb:1:in `each'
    from debian/ruby-tests.rb:1
