### PR TITLE
Fixing RDoc formatting of README.rdoc.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -2,23 +2,23 @@
 
 Mixlib::Log provides a mixin for enabling a class based logger object, a-la Merb, Chef, and Nanite.  To use it:
 
-	require 'mixlib/log'
-	
-	class Log
-		extend Mixlib::Log
-	end
-	
+  require 'mixlib/log'
+  	
+  class Log
+    extend Mixlib::Log
+  end
+
 You can then do:
 
-	Log.debug("foo")
-	Log.info("bar")
-	Log.warn("baz")
-	Log.error("baz")
-	Log.fatal("wewt")
-	
-By default, Mixlib::Logger logs to STDOUT.  To alter this, you should call Log.init, passing any arguments to the standard Ruby Logger.  For example:
+  Log.debug('foo')
+  Log.info('bar')
+  Log.warn('baz')
+  Log.error('baz')
+  Log.fatal('wewt')
 
-	Log.init("/tmp/logfile")    # log to /tmp/logfile
-	Log.init("/tmp/logfile", 7) # log to /tmp/logfile, rotate every day
-	
+By default, <tt>Mixlib::Logger</tt> logs to STDOUT. To alter this, you should call +Log.init+, passing any arguments to the standard Ruby Logger. For example:
+
+  Log.init('/tmp/logfile')  # log to /tmp/logfile
+  Log.init('/tmp/logfile', 7)  # log to /tmp/logfile, rotate every day
+
 Enjoy!


### PR DESCRIPTION
The markup in this doc was a little off, codeblocks weren't readable, etc. Fixed!
