### PR TITLE
Ensure that arguments to Mixlib::Log#add are passed as is to all loggers

### DIFF
--- a/lib/mixlib/log.rb
+++ b/lib/mixlib/log.rb
@@ -133,7 +133,7 @@ module Mixlib
     end
 
     def add(severity, message = nil, progname = nil, &block)
-      loggers.each {|l| l.add(severity, message = nil, progname = nil, &block) }
+      loggers.each {|l| l.add(severity, message, progname, &block) }
     end
 
     alias :log :add

--- a/spec/mixlib/log_spec.rb
+++ b/spec/mixlib/log_spec.rb
@@ -130,6 +130,15 @@ describe Mixlib::Log do
     lambda { Logit.debug("Gimme some sugar!") }.should_not raise_error
   end
 
+  it "should pass add method calls directly to logger" do
+    logdev = StringIO.new
+    Logit.init(logdev)
+    Logit.level = :debug
+    Logit.should be_debug
+    lambda { Logit.add(Logger::DEBUG, "Gimme some sugar!") }.should_not raise_error
+    logdev.string.should match(/Gimme some sugar/)
+  end
+
   it "should default to STDOUT if init is called with no arguments" do
     logger_mock = Struct.new(:formatter, :level).new
     Logger.stub!(:new).and_return(logger_mock)


### PR DESCRIPTION
I'm attempting to wrap mixlib log with ActiveRecord::TaggedLogger which calls #add on the logger it wraps, it so happens that Mixlib logger breaks in such a situation because it does not pass the arguments transparently to the loggers that it wraps in turn. Thereby causing the logs to print a log message with blank message in it.

For the implementation of TaggedLogger see https://github.com/rails/rails/blob/v3.2.6/activesupport/lib/active_support/tagged_logging.rb#L35
