### PR TITLE
adding caller to the log

### DIFF
--- a/lib/mixlib/log/formatter.rb
+++ b/lib/mixlib/log/formatter.rb
@@ -43,7 +43,7 @@ module Mixlib
       def msg2str(msg)
         case msg
         when ::String
-          msg
+          caller[8] + " : " + msg
         when ::Exception
           "#{ msg.message } (#{ msg.class })\n" <<
             (msg.backtrace || []).join("\n")


### PR DESCRIPTION
This little patch saves so much time, add the caller to the log statement.
