### PR TITLE
Travis: update Ruby versions, pass lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 2.2.5
-  - 2.3.1
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
 branches:
   only:
     - master
 before_install:
   - bundle --version
-  - gem --version
+  - gem update --system
 script:
   - bundle exec rake

--- a/features/steps/log.rb
+++ b/features/steps/log.rb
@@ -39,9 +39,9 @@ end
 
 Then /^the regex '(.+)' should be logged$/ do |regex_string|
   regex = Regexp.new(regex_string, Regexp::MULTILINE)
-  regex.match(@output).should_not == nil
+  expect(regex.match(@output)).not_to be_nil
 end
 
 Then /^nothing should be logged$/ do
-  @output.should == ""
+  expect(@output).to eq ""
 end

--- a/lib/mixlib/log/formatter.rb
+++ b/lib/mixlib/log/formatter.rb
@@ -45,7 +45,7 @@ module Mixlib
         when ::String
           msg
         when ::Exception
-          "#{ msg.message } (#{ msg.class })\n" <<
+          "#{msg.message} (#{msg.class})\n" <<
             (msg.backtrace || []).join("\n")
         else
           msg.inspect


### PR DESCRIPTION
This is a maintenance PR.

- Travis: Rubies matching ruby-build versions
- RSpec: Avoid deprecated `should`
- Rubygems update past 2.6.10, to be able to install Rainbow
- Rubocop: Pass lint