### PR TITLE
Logging methods (debug, info, warn, error, fatal) all return nil

### DIFF
--- a/lib/mixlib/log/logging.rb
+++ b/lib/mixlib/log/logging.rb
@@ -45,6 +45,7 @@ module Mixlib
         level = LEVELS[method_name]
         define_method(method_name) do |msg = nil, data: {}, &block|
           pass(level, msg, data: data, &block)
+          nil
         end
       end
 

--- a/spec/mixlib/log_spec.rb
+++ b/spec/mixlib/log_spec.rb
@@ -200,4 +200,17 @@ RSpec.describe Mixlib::Log do
     expect(opened_files_count_after).to eq(opened_files_count_before + 1)
   end
 
+  it "should return nil from its logging methods" do
+    expect(Logger).to receive(:new).with(STDOUT) { double("a-quiet-logger").as_null_object }
+    Logit.init
+
+    aggregate_failures "returns nil from logging method" do
+      expect(Logit.trace("hello")).to be_nil
+      expect(Logit.debug("hello")).to be_nil
+      expect(Logit.info("hello")).to be_nil
+      expect(Logit.warn("hello")).to be_nil
+      expect(Logit.error("hello")).to be_nil
+      expect(Logit.fatal("hello")).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
This PR makes `logger.debug "Hello"` return `nil`.

## Why would I need this?

Your existing code rescued and logged an exception using `warn`. The return value of that invocation was `nil`.

Someone comes along to upgrade that `warn` to use a configurable mixlib-log logger. The return value of that logged exception is now non-nil.

  - Fixes #21 
