### PR TITLE
RSpec: use 3.7, disable monkey patching mode

### DIFF
--- a/mixlib-log.gemspec
+++ b/mixlib-log.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.files = Dir["lib/**/*"] + Dir["spec/**/*"] + ["Gemfile", "Rakefile", ".gemtest", "mixlib-log.gemspec"]
   gem.required_ruby_version = ">= 2.2"
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "rspec", "~> 3.4"
+  gem.add_development_dependency "rspec", "~> 3.7"
   gem.add_development_dependency "chefstyle"
   gem.add_development_dependency "cucumber"
   gem.add_development_dependency "github_changelog_generator", ">= 1.11.3"

--- a/spec/mixlib/log/formatter_spec.rb
+++ b/spec/mixlib/log/formatter_spec.rb
@@ -19,7 +19,7 @@
 require "time"
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "spec_helper"))
 
-describe Mixlib::Log::Formatter do
+RSpec.describe Mixlib::Log::Formatter do
   before(:each) do
     @formatter = Mixlib::Log::Formatter.new
   end

--- a/spec/mixlib/log_spec.rb
+++ b/spec/mixlib/log_spec.rb
@@ -37,7 +37,7 @@ class LoggerLike
   end
 end
 
-describe Mixlib::Log do
+RSpec.describe Mixlib::Log do
 
   # Since we are testing class behaviour for an instance variable
   # that gets set once, we need to reset it prior to each example [cb]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,10 @@ require "rspec"
 require "mixlib/log"
 require "mixlib/log/formatter"
 
+RSpec.configure do |config|
+  config.disable_monkey_patching!
+end
+
 class Logit
   extend Mixlib::Log
 end


### PR DESCRIPTION
This PR upgrades RSpec in the gemspec to 3.7 and disables the monkey-patching needed to support bare "describe".