### PR TITLE
Remove the changelog generator gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -32,12 +32,3 @@ begin
 rescue LoadError
   puts "chefstyle/rubocop is not available.  gem install chefstyle to do style checking."
 end
-
-require "github_changelog_generator/task"
-
-GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-  config.future_release = Mixlib::Log::VERSION
-  config.enhancement_labels = "enhancement,Enhancement,New Feature,Feature".split(",")
-  config.bug_labels = "bug,Bug,Improvement,Upstream Bug".split(",")
-  config.exclude_labels = "duplicate,question,invalid,wontfix,no_changelog,Exclude From Changelog,Question,Discussion".split(",")
-end

--- a/mixlib-log.gemspec
+++ b/mixlib-log.gemspec
@@ -18,5 +18,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec", "~> 3.7"
   gem.add_development_dependency "chefstyle"
   gem.add_development_dependency "cucumber"
-  gem.add_development_dependency "github_changelog_generator", ">= 1.11.3"
 end


### PR DESCRIPTION
We're using expeditor now

Signed-off-by: Tim Smith <tsmith@chef.io>