### PR TITLE
Move gems to Gemfile & add new Rake tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,28 @@ source "https://rubygems.org"
 
 gemspec
 
-group :development do
-  gem "rdoc"
-  gem "bundler"
+group :docs do
+  gem "yard"
+  gem "redcarpet"
+  gem "github-markup"
 end
+
+group :test do
+  gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "master"
+  gem "rspec", "~> 3.4"
+  gem "cucumber"
+  gem "rake"
+end
+
+group :development do
+  gem "pry"
+  gem "pry-byebug"
+  gem "pry-stack_explorer"
+  gem "rb-readline"
+end
+
+instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
+
+# If you want to load debugging tools into the bundle exec sandbox,
+# add these additional dependencies into Gemfile.local
+eval_gemfile(__FILE__ + ".local") if File.exist?(__FILE__ + ".local")

--- a/README.md
+++ b/README.md
@@ -31,13 +31,21 @@ Log.init('/tmp/logfile', 7)  # log to /tmp/logfile, rotate every day
 
 Enjoy!
 
+## Documentation
+
+All documentation is written using YARD. You can generate a by running:
+
+```
+rake docs
+```
+
 ## Contributing
 
-For information on contributing to this project see <https://github.com/chef/chef/blob/master/CONTRIBUTING.md>
+For information on contributing to this project please see our [Contributing Documentation](https://github.com/chef/chef/blob/master/CONTRIBUTING.md)
 
-## License
+## License & Copyright
 
-- Copyright:: Copyright (c) 2008-2016 Chef Software, Inc.
+- Copyright:: Copyright (c) 2008-2018 Chef Software, Inc.
 - License:: Apache License, Version 2.0
 
 ```text

--- a/Rakefile
+++ b/Rakefile
@@ -1,22 +1,14 @@
 require "bundler/gem_tasks"
-require "rdoc/task"
 require "rspec/core/rake_task"
 require "cucumber/rake/task"
 
+task default: [:style, :spec :features]
+
+Bundler::GemHelper.install_tasks
+
+desc "Run specs"
 RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = "spec/**/*_spec.rb"
-end
-
-task default: [:style, :spec, :features]
-
-# For rubygems-test
-task test: :spec
-
-RDoc::Task.new do |rdoc|
-  rdoc.rdoc_dir = "rdoc"
-  rdoc.title = "mixlib-log #{Mixlib::Log::VERSION}"
-  rdoc.rdoc_files.include("README*")
-  rdoc.rdoc_files.include("lib/**/*.rb")
 end
 
 Cucumber::Rake::Task.new(:features) do |t|
@@ -30,14 +22,20 @@ begin
     task.options += ["--display-cop-names", "--no-color"]
   end
 rescue LoadError
-  puts "chefstyle/rubocop is not available.  gem install chefstyle to do style checking."
+  puts "chefstyle/rubocop is not available. bundle install first to make sure all dependencies are installed."
 end
 
-require "github_changelog_generator/task"
+begin
+  require "yard"
+  YARD::Rake::YardocTask.new(:docs)
+rescue LoadError
+  puts "yard is not available. bundle install first to make sure all dependencies are installed."
+end
 
-GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-  config.future_release = Mixlib::Log::VERSION
-  config.enhancement_labels = "enhancement,Enhancement,New Feature,Feature".split(",")
-  config.bug_labels = "bug,Bug,Improvement,Upstream Bug".split(",")
-  config.exclude_labels = "duplicate,question,invalid,wontfix,no_changelog,Exclude From Changelog,Question,Discussion".split(",")
+task :console do
+  require "irb"
+  require "irb/completion"
+  require "mixlib/log"
+  ARGV.clear
+  IRB.start
 end

--- a/mixlib-log.gemspec
+++ b/mixlib-log.gemspec
@@ -14,9 +14,4 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = ["README.md", "LICENSE", "NOTICE"]
   gem.files = Dir["lib/**/*"] + Dir["spec/**/*"] + ["Gemfile", "Rakefile", ".gemtest", "mixlib-log.gemspec"]
   gem.required_ruby_version = ">= 2.2"
-  gem.add_development_dependency "rake"
-  gem.add_development_dependency "rspec", "~> 3.7"
-  gem.add_development_dependency "chefstyle"
-  gem.add_development_dependency "cucumber"
-  gem.add_development_dependency "github_changelog_generator", ">= 1.11.3"
 end


### PR DESCRIPTION
Switch from rdoc to yard. Add console task / irb like our other gems. Remove the old changelog generator task

Signed-off-by: Tim Smith <tsmith@chef.io>