### PR TITLE
reverting back to ruby 2.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ before_install:
 
 matrix:
   include:
+    - rvm: 2.3.8
+    - rvm: 2.4.5
     - rvm: 2.5.3
     - rvm: 2.6
     - rvm: ruby-head

--- a/mixlib-log.gemspec
+++ b/mixlib-log.gemspec
@@ -11,5 +11,5 @@ Gem::Specification.new do |gem|
   gem.authors = ["Chef Software, Inc."]
   gem.files = %w{LICENSE} + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   gem.require_paths = ["lib"]
-  gem.required_ruby_version = ">= 2.5"
+  gem.required_ruby_version = ">= 2.3"
 end


### PR DESCRIPTION
it appears we break the world if we go to >= 2.5 and we need to
do this a bit more cautiously.
