### PR TITLE
Add whitespace, to avoid YARD warning

### DIFF
--- a/lib/mixlib/log.rb
+++ b/lib/mixlib/log.rb
@@ -36,7 +36,7 @@ module Mixlib
     end
 
     # An Array of log devices that will be logged to. Defaults to just the default
-    # @logger log device, but you can push to this array to add more devices.
+    #   @logger log device, but you can push to this array to add more devices.
     def loggers
       @loggers ||= [logger]
     end


### PR DESCRIPTION
### Description

This PR edits a YARD documentation annotation.

With the whitespace, YARD no longer thinks "at-sign logger" is a directive to YARD

### Issues Resolved

None.

### Check List

- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
