### PR TITLE
Escape YARD annotation to avoid directive

### DIFF
--- a/lib/mixlib/log.rb
+++ b/lib/mixlib/log.rb
@@ -36,7 +36,7 @@ module Mixlib
     end
 
     # An Array of log devices that will be logged to. Defaults to just the default
-    #   @logger log device, but you can push to this array to add more devices.
+    # \@logger log device, but you can push to this array to add more devices.
     def loggers
       @loggers ||= [logger]
     end


### PR DESCRIPTION

### Description

In #49, I made a change to avoid a warning. Now, I took a second look at the output, and it rendered wrong.

This PR uses the YARD escape notation, to avoid a warning AND to avoid the whitespace rendering as a monospace-formatted section.

### Issues Resolved

None.
