### PR TITLE
Resolve all warnings emitted during testing

### DIFF
--- a/lib/mixlib/log.rb
+++ b/lib/mixlib/log.rb
@@ -27,11 +27,12 @@ module Mixlib
   module Log
 
     include Logging
-    @logger, @loggers = nil
 
     def reset!
+      @logger  ||= nil
+      @loggers ||= []
       close!
-      @logger, @loggers = nil, nil
+      @logger = @loggers = nil
       @metadata = {}
     end
 

--- a/lib/mixlib/log.rb
+++ b/lib/mixlib/log.rb
@@ -46,7 +46,7 @@ module Mixlib
     # and creates a new one if it doesn't yet exist
     ##
     def logger
-      @logger || init
+      @logger ||= init
     end
 
     # Sets the log device to +new_log_device+. Any additional loggers

--- a/lib/mixlib/log.rb
+++ b/lib/mixlib/log.rb
@@ -170,7 +170,7 @@ module Mixlib
 
     def logger_for(*opts)
       if opts.empty?
-        Mixlib::Log::Logger.new(STDOUT)
+        Mixlib::Log::Logger.new($stdout)
       elsif LEVELS.keys.inject(true) { |quacks, level| quacks && opts.first.respond_to?(level) }
         opts.first
       else

--- a/lib/mixlib/log.rb
+++ b/lib/mixlib/log.rb
@@ -190,6 +190,7 @@ module Mixlib
         # via public API. In order to reduce amount of impact and
         # handle only File type log devices I had to use this method
         # to get access to it.
+        next unless logger.instance_variable_defined?(:"@logdev")
         next unless (logdev = logger.instance_variable_get(:"@logdev"))
         loggers_to_close << logger if logdev.filename
       end

--- a/lib/mixlib/log/logger.rb
+++ b/lib/mixlib/log/logger.rb
@@ -21,7 +21,7 @@ module Mixlib
       #
       # +logdev+::
       #   The log device.  This is a filename (String) or IO object (typically
-      #   +STDOUT+, +STDERR+, or an open file).
+      #   +$stdout+, +$stderr+, or an open file).
       # +shift_age+::
       #   Number of old log files to keep, *or* frequency of rotation (+daily+,
       #   +weekly+ or +monthly+).

--- a/spec/mixlib/log_spec.rb
+++ b/spec/mixlib/log_spec.rb
@@ -142,9 +142,14 @@ RSpec.describe Mixlib::Log do
   end
 
   it "should pass other method calls directly to logger" do
-    Logit.level = :debug
-    expect(Logit).to be_debug
-    expect { Logit.debug("Gimme some sugar!") }.to_not raise_error
+    expect do
+      # this needs to be inside of the block because the level setting
+      # is causing the init, which grabs $stderr before rspec replaces
+      # it for output testing.
+      Logit.level = :debug
+      expect(Logit).to be_debug
+      Logit.debug("Gimme some sugar!")
+    end.to output(/DEBUG: Gimme some sugar!/).to_stdout
   end
 
   it "should pass add method calls directly to logger" do
@@ -158,6 +163,7 @@ RSpec.describe Mixlib::Log do
 
   it "should default to STDOUT if init is called with no arguments" do
     logger_mock = Struct.new(:formatter, :level).new
+    # intentionally STDOUT to avoid unfailable test
     expect(Logger).to receive(:new).with(STDOUT).and_return(logger_mock)
     Logit.init
   end
@@ -203,6 +209,7 @@ RSpec.describe Mixlib::Log do
   end
 
   it "should return nil from its logging methods" do
+    # intentionally STDOUT to avoid unfailable test
     expect(Logger).to receive(:new).with(STDOUT) { double("a-quiet-logger").as_null_object }
     Logit.init
 

--- a/spec/mixlib/log_spec.rb
+++ b/spec/mixlib/log_spec.rb
@@ -134,17 +134,17 @@ RSpec.describe Mixlib::Log do
   end
 
   it "should raise an ArgumentError if you try and set the level to something strange using the binding form" do
-    expect(lambda { Logit.level = :the_roots }).to raise_error(ArgumentError)
+    expect { Logit.level = :the_roots }.to raise_error(ArgumentError)
   end
 
   it "should raise an ArgumentError if you try and set the level to something strange using the method form" do
-    expect(lambda { Logit.level(:the_roots) }).to raise_error(ArgumentError)
+    expect { Logit.level(:the_roots) }.to raise_error(ArgumentError)
   end
 
   it "should pass other method calls directly to logger" do
     Logit.level = :debug
     expect(Logit).to be_debug
-    expect(lambda { Logit.debug("Gimme some sugar!") }).to_not raise_error
+    expect { Logit.debug("Gimme some sugar!") }.to_not raise_error
   end
 
   it "should pass add method calls directly to logger" do
@@ -152,7 +152,7 @@ RSpec.describe Mixlib::Log do
     Logit.init(logdev)
     Logit.level = :debug
     expect(Logit).to be_debug
-    expect(lambda { Logit.add(Logger::DEBUG, "Gimme some sugar!") }).to_not raise_error
+    expect { Logit.add(Logger::DEBUG, "Gimme some sugar!") }.to_not raise_error
     expect(logdev.string).to match(/Gimme some sugar/)
   end
 


### PR DESCRIPTION
This removes all warnings emitted during testing of mixlib-log or inspec.

## Description

`ruby -w`, `rspec -w`, and `minitest -w` all run with `$-w = true` and output warnings on use of uninitialized variables among other things. This PR cleans those up for this project. It also changes some tests around to be more idiomatic and to avoid logging going to stdout on top of the rspec output.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [o] I have updated the documentation accordingly.
- [o] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
