### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/mixlib/log.rb
+++ b/lib/mixlib/log.rb
@@ -17,11 +17,11 @@
 # limitations under the License.
 
 require "logger"
-require "mixlib/log/version"
-require "mixlib/log/formatter"
-require "mixlib/log/child"
-require "mixlib/log/logging"
-require "mixlib/log/logger"
+require_relative "log/version"
+require_relative "log/formatter"
+require_relative "log/child"
+require_relative "log/logging"
+require_relative "log/logger"
 
 module Mixlib
   module Log

--- a/lib/mixlib/log/child.rb
+++ b/lib/mixlib/log/child.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "mixlib/log/logging"
+require_relative "logging"
 
 module Mixlib
   module Log

--- a/lib/mixlib/log/logger.rb
+++ b/lib/mixlib/log/logger.rb
@@ -1,5 +1,5 @@
 require "logger"
-require "mixlib/log/logging"
+require_relative "logging"
 
 # A subclass of Ruby's stdlib Logger with all the mutex and logrotation stuff
 # ripped out, and metadata added in.


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>