### PR TITLE
Support ruby3.3 Logger by properly initialize super class

### DIFF
--- a/lib/mixlib/log/logger.rb
+++ b/lib/mixlib/log/logger.rb
@@ -33,11 +33,7 @@ module Mixlib
       # Create an instance.
       #
       def initialize(logdev)
-        @progname = nil
-        @level = DEBUG
-        @default_formatter = Formatter.new
-        @formatter = nil
-        @logdev = nil
+        super(nil)
         if logdev
           @logdev = LocklessLogDevice.new(logdev)
         end


### PR DESCRIPTION
Upcoming ruby3.3 will have enhanced Logger class:
https://github.com/ruby/ruby/commit/194520f80e1cdb71faa055d731450855a1ddb8d1 which initializes newly added instance variables.
Without initializing such variables (in super class), now using subclass of Logger will cause exception.

To avoid this, first call super, then execute additional subclass initialization.

Fixes #73.

<!--- Provide a short summary of your changes in the Title above -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
