### PR TITLE
Fix formatter regression from Ruby 3.3 Logger fix

### DIFF
--- a/lib/mixlib/log/logger.rb
+++ b/lib/mixlib/log/logger.rb
@@ -33,7 +33,7 @@ module Mixlib
       # Create an instance.
       #
       def initialize(logdev)
-        super(nil)
+        super(nil, formatter: ::Mixlib::Log::Formatter.new)
         if logdev
           @logdev = LocklessLogDevice.new(logdev)
         end

--- a/spec/mixlib/log/logger_spec.rb
+++ b/spec/mixlib/log/logger_spec.rb
@@ -1,0 +1,29 @@
+# Copyright:: Copyright (c) 2024 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+RSpec.describe Mixlib::Log::Logger do
+  let(:io) { StringIO.new }
+
+  subject { described_class.new(io) }
+
+  it "logs a info message in text format" do
+    subject.info("test message")
+
+    expect(io.string).to match(/INFO: test message/)
+  end
+end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

https://github.com/chef/mixlib-log/pull/74 fixed an issue with Ruby 3.3's version of Logger. However, it dropped `Mixlib::Log::Formatter` from the formatter, so all messages now output as a Hash instead of a string.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
