### PR TITLE
Move ffi dependency forward

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -8,22 +8,6 @@ expeditor:
 
 steps:
 
-- label: run-lint-and-specs-ruby-2.7
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.7
-
-- label: run-lint-and-specs-ruby-3.0
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:3.0
-
 - label: run-lint-and-specs-ruby-3.1
   command:
     - .expeditor/run_linux_tests.sh rake
@@ -32,16 +16,13 @@ steps:
       docker:
         image: ruby:3.1
 
-- label: run-specs-ruby-3.0-windows
+- label: run-lint-and-specs-ruby-3.3
   command:
-    - .expeditor/run_windows_tests.ps1
+    - .expeditor/run_linux_tests.sh rake
   expeditor:
     executor:
       docker:
-        host_os: windows
-        shell: ["powershell", "-Command"]
-        image: rubydistros/windows-2019:3.0
-        user: 'NT AUTHORITY\SYSTEM'
+        image: ruby:3.3
 
 - label: run-specs-ruby-3.1-windows
   command:
@@ -52,4 +33,15 @@ steps:
         host_os: windows
         shell: ["powershell", "-Command"]
         image: rubydistros/windows-2019:3.1
+        user: 'NT AUTHORITY\SYSTEM'
+
+- label: run-specs-ruby-3.3-windows
+  command:
+    - .expeditor/run_windows_tests.ps1
+  expeditor:
+    executor:
+      docker:
+        host_os: windows
+        shell: ["powershell", "-Command"]
+        image: rubydistros/windows-2019:3.3
         user: 'NT AUTHORITY\SYSTEM'

--- a/mixlib-log.gemspec
+++ b/mixlib-log.gemspec
@@ -11,7 +11,8 @@ Gem::Specification.new do |gem|
   gem.authors = ["Chef Software, Inc."]
   gem.files = %w{LICENSE} + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   gem.require_paths = ["lib"]
-  gem.required_ruby_version = ">= 2.7"
+  gem.required_ruby_version = ">= 3.1"
 
-  gem.add_dependency "ffi", "< 1.17.0"
+  # 1.17.1 is broken, see: https://github.com/ffi/ffi/issues/1139
+  gem.add_dependency "ffi", "~> 1.9", "<= 1.17.0"
 end


### PR DESCRIPTION
This is required for Ruby 3.3, but works on 3.1+

Limiting FFI to 1.17.0 because of https://github.com/ffi/ffi/issues/1139