### PR TITLE
Relax ffi dependency to allow 1.17.1 and up

### DIFF
--- a/mixlib-log.gemspec
+++ b/mixlib-log.gemspec
@@ -13,6 +13,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.required_ruby_version = ">= 3.1"
 
-  # 1.17.1 is broken, see: https://github.com/ffi/ffi/issues/1139
-  gem.add_dependency "ffi", ">= 1.15.5", "< 1.17.0"
+  gem.add_dependency "ffi", ">= 1.15.5"
 end


### PR DESCRIPTION
https://github.com/chef/mixlib-log/pull/81 limited the ffi version to <= 1.17.0, but it's not actually broken as explained in https://github.com/ffi/ffi/issues/1139#issuecomment-2632381142.

The issues Chef are having are specific to precompiled native Gems on Omnibus Chef builds.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
