### PR TITLE
Unpin FFI

### DIFF
--- a/mixlib-log.gemspec
+++ b/mixlib-log.gemspec
@@ -13,6 +13,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.required_ruby_version = ">= 3.1"
 
-  # 1.17.1 is broken, see: https://github.com/ffi/ffi/issues/1139
-  gem.add_dependency "ffi", ">= 1.15.5", "< 1.17.0"
+  gem.add_dependency "ffi", ">= 1.15.5"
 end


### PR DESCRIPTION
```shell
$ bundle update --conservative ffi
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Resolving dependencies...
Bundler attempted to update ffi but its version stayed the same
Bundle updated!
```

Replaces #82. Tried adding force_ruby_platform but it had it's own 
issues... but don't think it's needed, as this isn't put in omnibus 
directly, only via chef/ohai/workstation.

And #82 is stick and stanhu hasn't replied to kick it, so I'm hoping
to move the transition along.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
